### PR TITLE
Play sounds from directories with spaces

### DIFF
--- a/playsound.py
+++ b/playsound.py
@@ -55,7 +55,8 @@ def _playsoundOSX(sound, block = True):
     from AppKit     import NSSound
     from Foundation import NSURL
     from time       import sleep
-
+    
+    sound = sound.replace(" ", "%20")
     if '://' not in sound:
         if not sound.startswith('/'):
             from os import getcwd


### PR DESCRIPTION
For Mac, Package was erroring out if trying to place a sound file which had a space in its absolute address. This fixes that by replacing a space with a '%20," as you would need to call the file from a browser.