### PR TITLE
Close windows stream after playing sound

### DIFF
--- a/playsound.py
+++ b/playsound.py
@@ -36,9 +36,12 @@ def _playsoundWin(sound, block = True):
     winCommand('set', alias, 'time format milliseconds')
     durationInMS = winCommand('status', alias, 'length')
     winCommand('play', alias, 'from 0 to', durationInMS.decode())
-
+    
     if block:
         sleep(float(durationInMS) / 1000.0)
+        
+    winCommand('close', alias)
+    
 
 def _playsoundOSX(sound, block = True):
     '''


### PR DESCRIPTION
This fixes a bug where the windows stream isn't closed after playing the sound