### PR TITLE
Always set the Gstreamer Element state to NULL

### DIFF
--- a/playsound.py
+++ b/playsound.py
@@ -108,8 +108,10 @@ def _playsoundNix(sound, block=True):
     # FIXME: use some other bus method than poll() with block=False
     # https://lazka.github.io/pgi-docs/#Gst-1.0/classes/Bus.html
     bus = playbin.get_bus()
-    bus.poll(Gst.MessageType.EOS, Gst.CLOCK_TIME_NONE)
-    playbin.set_state(Gst.State.NULL)
+    try:
+        bus.poll(Gst.MessageType.EOS, Gst.CLOCK_TIME_NONE)
+    finally:
+        playbin.set_state(Gst.State.NULL)
 
 
 from platform import system


### PR DESCRIPTION
Ensures that the Gstreamer Element state will always be set to NULL. This caused GStreamer to flood you with CRITICAL errors if a `KeyboardInterrupt` was raised.