### PR TITLE
Added async feature to Linux OS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-playsound
+playsound -> soundplay, new fork
 =========
 *Pure Python, cross platform, single function module with no dependencies for playing sounds.*
 

--- a/playsound.py
+++ b/playsound.py
@@ -70,15 +70,11 @@ def _playsoundOSX(sound, block = True):
     if block:
         sleep(nssound.duration())
 
-def _playsoundNix(sound, block=True):
+def linuxPlay(sound, block):
     """Play a sound using GStreamer.
-
     Inspired by this:
     https://gstreamer.freedesktop.org/documentation/tutorials/playback/playbin-usage.html
     """
-    if not block:
-        raise NotImplementedError(
-            "block=False cannot be used on this platform yet")
 
     # pathname2url escapes non-URL-safe characters
     import os
@@ -111,6 +107,12 @@ def _playsoundNix(sound, block=True):
     bus.poll(Gst.MessageType.EOS, Gst.CLOCK_TIME_NONE)
     playbin.set_state(Gst.State.NULL)
 
+def _playsoundNix(sound, block=True):
+    from threading import Thread
+    T=Thread(target=lambda: linuxPlay(sound, block))
+    T.setDaemon(True)
+    T.start()
+    if block==True:T.join()
 
 from platform import system
 system = system()

--- a/playsound.py
+++ b/playsound.py
@@ -70,7 +70,7 @@ def _playsoundOSX(sound, block = True):
     if block:
         sleep(nssound.duration())
 
-def linuxPlay(sound, block):
+def linuxPlay(sound):
     """Play a sound using GStreamer.
     Inspired by this:
     https://gstreamer.freedesktop.org/documentation/tutorials/playback/playbin-usage.html
@@ -109,7 +109,7 @@ def linuxPlay(sound, block):
 
 def _playsoundNix(sound, block=True):
     from threading import Thread
-    T=Thread(target=lambda: linuxPlay(sound, block))
+    T=Thread(target=lambda: linuxPlay(sound))
     T.setDaemon(True)
     T.start()
     if block==True:T.join()

--- a/soundplay.py
+++ b/soundplay.py
@@ -1,3 +1,6 @@
+#all credit given to Taylor S Marks copyright playsound and this is a fork of
+#his project.  This is the latest version as of 6/16/2021, but I made the
+#Linux OS have the async or block=False argument.
 class PlaysoundException(Exception):
     pass
 
@@ -7,10 +10,8 @@ def _playsoundWin(sound, block = True):
     Windows 7 with Python 2.7. Probably works with more file formats.
     Probably works on Windows XP thru Windows 10. Probably works with all
     versions of Python.
-
     Inspired by (but not copied from) Michael Gundlach <gundlach@gmail.com>'s mp3play:
     https://github.com/michaelgundlach/mp3play
-
     I never would have tried using windll.winmm without seeing his code.
     '''
     from ctypes import c_buffer, windll
@@ -46,10 +47,8 @@ def _playsoundOSX(sound, block = True):
     OS X 10.11 with Python 2.7. Probably works with anything QuickTime supports.
     Probably works on OS X 10.5 and newer. Probably works with all versions of
     Python.
-
     Inspired by (but not copied from) Aaron's Stack Overflow answer here:
     http://stackoverflow.com/a/34568298/901641
-
     I never would have tried using AppKit.NSSound without seeing his code.
     '''
     from AppKit     import NSSound
@@ -118,10 +117,10 @@ from platform import system
 system = system()
 
 if system == 'Windows':
-    playsound = _playsoundWin
+    soundplay = _playsoundWin
 elif system == 'Darwin':
-    playsound = _playsoundOSX
+    soundplay = _playsoundOSX
 else:
-    playsound = _playsoundNix
+    soundplay = _playsoundNix
 
 del system


### PR DESCRIPTION
In order to use async play of music in Linux I had to use threads.  There is a main section where a function is that plays the file Linux.  I start that function as a thread.  If block is true, I immediately join the thread so it must complete before its parent continues.  Otherwise it should execute on its own until completion. 