### PR TITLE
Support passing in a pathlib.Path by converting to str (V2)

### DIFF
--- a/playsound.py
+++ b/playsound.py
@@ -16,6 +16,9 @@ def _playsoundWin(sound, block = True):
     from ctypes import c_buffer, windll
     from time   import sleep
 
+    # Support passing in a pathlib.Path
+    sound = str(sound)
+
     def winCommand(*command):
         bufLen = 600
         buf = c_buffer(bufLen)
@@ -45,6 +48,9 @@ def _playsoundWin(sound, block = True):
             pass
 
 def _handlePathOSX(sound):
+    # Support passing in a pathlib.Path
+    sound = str(sound)
+
     if '://' not in sound:
         if not sound.startswith('/'):
             from os import getcwd
@@ -111,6 +117,9 @@ def _playsoundNix(sound, block = True):
     Inspired by this:
     https://gstreamer.freedesktop.org/documentation/tutorials/playback/playbin-usage.html
     """
+    # Support passing in a pathlib.Path
+    sound = str(sound)
+
     if not block:
         raise NotImplementedError(
             "block=False cannot be used on this platform yet")

--- a/playsound.py
+++ b/playsound.py
@@ -1,6 +1,18 @@
 class PlaysoundException(Exception):
     pass
 
+def _canonicalizePath(path):
+    """
+    Support passing in a pathlib.Path-like object by converting to str.
+    """
+    import sys
+    if sys.version_info[0] >= 3:
+        return str(path)
+    else:
+        # On earlier Python versions, str is a byte string, so attempting to
+        # convert a unicode string to str will fail. Leave it alone in this case.
+        return path
+
 def _playsoundWin(sound, block = True):
     '''
     Utilizes windll.winmm. Tested and known to work with MP3 and WAVE on
@@ -16,8 +28,7 @@ def _playsoundWin(sound, block = True):
     from ctypes import c_buffer, windll
     from time   import sleep
 
-    # Support passing in a pathlib.Path
-    sound = str(sound)
+    sound = _canonicalizePath(sound)
 
     def winCommand(*command):
         bufLen = 600
@@ -48,8 +59,7 @@ def _playsoundWin(sound, block = True):
             pass
 
 def _handlePathOSX(sound):
-    # Support passing in a pathlib.Path
-    sound = str(sound)
+    sound = _canonicalizePath(sound)
 
     if '://' not in sound:
         if not sound.startswith('/'):
@@ -117,8 +127,7 @@ def _playsoundNix(sound, block = True):
     Inspired by this:
     https://gstreamer.freedesktop.org/documentation/tutorials/playback/playbin-usage.html
     """
-    # Support passing in a pathlib.Path
-    sound = str(sound)
+    sound = _canonicalizePath(sound)
 
     if not block:
         raise NotImplementedError(
@@ -167,8 +176,7 @@ def _playsoundAnotherPython(otherPython, sound, block = True):
     from subprocess import check_call
     from threading  import Thread
 
-    # Support passing in a pathlib.Path
-    sound = str(sound)
+    sound = _canonicalizePath(sound)
 
     class PropogatingThread(Thread):
         def run(self):

--- a/playsound.py
+++ b/playsound.py
@@ -167,6 +167,9 @@ def _playsoundAnotherPython(otherPython, sound, block = True):
     from subprocess import check_call
     from threading  import Thread
 
+    # Support passing in a pathlib.Path
+    sound = str(sound)
+
     class PropogatingThread(Thread):
         def run(self):
             self.exc = None

--- a/test.py
+++ b/test.py
@@ -44,10 +44,14 @@ def mockMciSendStringW(command, buf, bufLen, bufStart):
     return 0
 
 class PlaysoundTests(unittest.TestCase):
-    def helper(self, file, approximateDuration, block = True):
-        startTime = time()
+    def get_full_path(self, file):
         path = join('test_media', file)
         print(path.encode('utf-8'))
+        return path
+
+    def helper(self, file, approximateDuration, block = True):
+        startTime = time()
+        path = self.get_full_path(file)
 
         if isTravis and system == 'Windows':
             with patch('ctypes.windll.winmm.mciSendStringW', side_effect = mockMciSendStringW):
@@ -68,12 +72,22 @@ class PlaysoundTests(unittest.TestCase):
 
     def testMissing(self):
         with self.assertRaises(PlaysoundException) as context:
-            playsound('notarealfile.wav')
+            playsound(self.get_full_path('notarealfile.wav'))
 
             message = context.exception.message.lower()
 
             for sub in ['cannot', 'find', 'filename', 'notarealfile.wav']:
                 self.assertIn(sub, message.lower(), '"{}" was expected in the exception message, but instead got: "{}"'.format(sub, message))
+
+# Run the same tests as above, but pass pathlib.Path objects to playsound instead of strings.
+try:
+    from pathlib import Path
+except ImportError:
+    pass
+else:
+    class PlaysoundTestsWithPathlib(PlaysoundTests):
+        def get_full_path(self, file):
+            return Path('test_media') / file
 
 if __name__ == '__main__':
     print(version)


### PR DESCRIPTION
This is the same branch as PR #68, but that PR didn't update when I pushed the new version of the branch (presumably because it was closed).

For the tests, I made a subclass that runs the same tests as `PlaysoundTests`, but generates a pathlib.Path object instead of a string. This way any tests added to `PlaysoundTests` will automatically get a version with pathlib.Path on supported platforms.