### PR TITLE
fix: close at the start of playback, try to close when opening fails

### DIFF
--- a/playsound.py
+++ b/playsound.py
@@ -1,6 +1,8 @@
 import logging
 logger = logging.getLogger(__name__)
 
+_openedSoundsWin = []
+
 class PlaysoundException(Exception):
     pass
 
@@ -52,12 +54,20 @@ def _playsoundWin(sound, block = True):
 
     try:
         logger.debug('Starting')
+        if (sound in _openedSoundsWin):
+            winCommand(u'close {}'.format(sound))
+            _openedSoundsWin.remove(sound)
         winCommand(u'open {}'.format(sound))
         winCommand(u'play {}{}'.format(sound, ' wait' if block else ''))
+        if not block:
+            _openedSoundsWin.append(sound)
         logger.debug('Returning')
     finally:
         try:
-            winCommand(u'close {}'.format(sound))
+            if (block):
+                winCommand(u'close {}'.format(sound))
+            else:
+                pass
         except PlaysoundException:
             logger.warning(u'Failed to close the file: {}'.format(sound))
             # If it fails, there's nothing more that can be done...

--- a/playsound.py
+++ b/playsound.py
@@ -31,14 +31,12 @@ def _playsoundWin(sound, block = True):
     sound = '"' + _canonicalizePath(sound) + '"'
 
     from ctypes import create_unicode_buffer, windll, wintypes
-    from time   import sleep
     windll.winmm.mciSendStringW.argtypes = [wintypes.LPCWSTR, wintypes.LPWSTR, wintypes.UINT, wintypes.HANDLE]
     windll.winmm.mciGetErrorStringW.argtypes = [wintypes.DWORD, wintypes.LPWSTR, wintypes.UINT]
 
-    def winCommand(*command):
+    def winCommand(command):
         bufLen = 600
         buf = create_unicode_buffer(bufLen)
-        command = ' '.join(command)
         errorCode = int(windll.winmm.mciSendStringW(command, buf, bufLen - 1, 0))  # use widestring version of the function
         if errorCode:
             errorBuffer = create_unicode_buffer(bufLen)
@@ -48,11 +46,10 @@ def _playsoundWin(sound, block = True):
                                 '\n    ' + errorBuffer.value)
             logger.error(exceptionMessage)
             raise PlaysoundException(exceptionMessage)
-        return buf.value
 
+    logger.debug('Starting')
+    winCommand(u'open {}'.format(sound))
     try:
-        logger.debug('Starting')
-        winCommand(u'open {}'.format(sound))
         winCommand(u'play {}{}'.format(sound, ' wait' if block else ''))
         logger.debug('Returning')
     finally:
@@ -61,7 +58,6 @@ def _playsoundWin(sound, block = True):
         except PlaysoundException:
             logger.warning(u'Failed to close the file: {}'.format(sound))
             # If it fails, there's nothing more that can be done...
-            pass
 
 def _handlePathOSX(sound):
     sound = _canonicalizePath(sound)

--- a/playsound.py
+++ b/playsound.py
@@ -51,26 +51,27 @@ def _playsoundWin(sound, block = True):
 
     logger.debug('Starting')
     winCommand(u'open {}'.format(sound))
+    for old in _openedSoundsWin.copy():
+        try:
+            winCommand(u'close {}'.format(old))
+        except PlaysoundException:
+            logger.warning(u'Failed to close the file: {}'.format(old))
+        _openedSoundsWin.remove(old)
     try:
-        for old in _openedSoundsWin.copy():
-            try:
-                winCommand(u'close {}'.format(old))
-            except PlaysoundException:
-                logger.warning(u'Failed to close the file: {}'.format(old))
-            _openedSoundsWin.remove(old)
         winCommand(u'play {}{}'.format(sound, ' wait' if block else ''))
         if not block:
             _openedSoundsWin.append(sound)
         logger.debug('Returning')
+    except PlaysoundException as e:
+        winCommand(u'close {}'.format(sound))
+        raise e
     finally:
-        try:
-            if (block):
+        if block:
+            try:
                 winCommand(u'close {}'.format(sound))
-            else:
-                pass
-        except PlaysoundException:
-            logger.warning(u'Failed to close the file: {}'.format(sound))
-            # If it fails, there's nothing more that can be done...
+            except PlaysoundException:
+                logger.warning(u'Failed to close the file: {}'.format(sound))
+                # If it fails, there's nothing more that can be done...
 
 def _handlePathOSX(sound):
     sound = _canonicalizePath(sound)

--- a/test.py
+++ b/test.py
@@ -31,7 +31,7 @@ if isTravis and system == 'Windows':
         # versions require python 3.3, utterly defeating the purpose of making
         # the library available on pypi.
         pipmain(['install', 'mock==2.0.0'])
-        from mock   import patch
+        from mock import patch
 
 from playsound import playsound, PlaysoundException
 import unittest
@@ -63,35 +63,52 @@ class PlaysoundTests(unittest.TestCase):
         print(path.encode('utf-8'))
         return path
 
-    def helper(self, file, approximateDuration, block = True):
+    def helper(self, file, approximateDuration, block = True, usingMciSendStringW = True):
         startTime = time()
         path = self.get_full_path(file)
 
         if isTravis and system == 'Windows':
-            with patch('ctypes.windll.winmm.mciSendStringW', side_effect = mockMciSendStringW):
-                global expectedDuration, sawClose, testCase
-                testCase = self
-                sawClose = False
-                expectedDuration = approximateDuration
+            if usingMciSendStringW:
+                with patch('ctypes.windll.winmm.mciSendStringW', side_effect = mockMciSendStringW):
+                    global expectedDuration, sawClose, testCase
+                    testCase = self
+                    sawClose = False
+                    expectedDuration = approximateDuration
+                    playsound(path, block = block)
+                    self.assertTrue(sawClose)
+            else:
                 playsound(path, block = block)
-                self.assertTrue(sawClose)
+                sleep(3)
         else:
             playsound(path, block = block)
         duration = time() - startTime
         self.assertTrue(approximateDuration - durationMarginLow <= duration <= approximateDuration + duratingMarginHigh, 'File "{}" took an unexpected amount of time: {:.2f} - expected ~{:.2f}'.format(file.encode('utf-8'), duration, approximateDuration))
 
     testBlockingASCII_MP3 = lambda self: self.helper('Damonte.mp3', 1.1)
-    testBlockingASCII_WAV = lambda self: self.helper('Sound4.wav',  1.3)
+    testBlockingASCII_WAV = lambda self: self.helper('Sound4.wav', 1.3)
     testBlockingCYRIL_WAV = lambda self: self.helper(u'Буква_Я.wav', 1.6)
     testBlockingSPACE_MP3 = lambda self: self.helper('Discovery - Go at throttle up (2).mp3', 2.3)
-    testNonBlockingRepeat = lambda self: self.helper(u'Буква_Я.wav', 0.0, block = False)
+    testNonBlockingASCII_MP31 = lambda self: self.helper('Damonte.mp3', 0.0, block = False)
+    testNonBlockingASCII_WAV1 = lambda self: self.helper('Sound4.wav', 0.0, block = False)
+    testNonBlockingCYRIL_WAV1 = lambda self: self.helper(u'Буква_Я.wav', 0.0, block = False)
+    testNonBlockingSPACE_MP31 = lambda self: self.helper('Discovery - Go at throttle up (2).mp3', 0.0, block = False)
+    if system == 'Windows':
+        testNonBlockingASCII_MP30 = lambda self: self.helper('Damonte.mp3', 0.0, block = False, usingMciSendStringW = False)
+        testNonBlockingASCII_WAV0 = lambda self: self.helper('Sound4.wav', 0.0, block = False, usingMciSendStringW = False)
+        testNonBlockingCYRIL_WAV0 = lambda self: self.helper(u'Буква_Я.wav', 0.0, block = False, usingMciSendStringW = False)
+        testNonBlockingSPACE_MP30 = lambda self: self.helper('Discovery - Go at throttle up (2).mp3', 0.0, block = False, usingMciSendStringW = False)
 
     def testMissing(self):
         with self.assertRaises(PlaysoundException) as context:
             playsound(self.get_full_path('fakefile.wav'))
-
         message = str(context.exception).lower()
-            
+        for sub in ['not', 'fakefile.wav']:
+            self.assertIn(sub, message, '"{}" was expected in the exception message, but instead got: "{}"'.format(sub, message))
+
+    def testMissing2(self):
+        with self.assertRaises(PlaysoundException) as context:
+            playsound(self.get_full_path('fakefile.wav'), block = False)
+        message = str(context.exception).lower()
         for sub in ['not', 'fakefile.wav']:
             self.assertIn(sub, message, '"{}" was expected in the exception message, but instead got: "{}"'.format(sub, message))
 


### PR DESCRIPTION
fix: close at the start of playback on Windows, block=False;
fix: try to close when opening fails on Windows;

`test.py` passed on my local system (`Windows 10`, `Python 3.9.13` and `Python 2.7.18`).