### PR TITLE
Fix installing from sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 from codecs     import open
-from inspect    import getsource
 from os.path    import abspath, dirname, join
 from setuptools import setup
 
-here = abspath(dirname(getsource(lambda:0)))
+here = abspath(dirname(__file__))
 
 with open(join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()


### PR DESCRIPTION
Fixes #145 and fixes #143.

See my comment in https://github.com/TaylorSMarks/playsound/issues/143#issuecomment-1535353847 for why this change is needed.

In case this PR takes a while to be merged, users can install it from git via

```
pip install git+https://github.com/mattmess1221/playsound.git